### PR TITLE
Add PureScript Halogen frontend for PostgREST verse explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,28 @@ DeepBible is a pipeline for downloading and processing biblical texts from ph4.o
  ```
  This uploads the `_sources`, `_books`, and `_all_verses` tables to schemas named by each language code.
 
- ## Directory Structure
- ```
- .
- ├── Makefile            # Pipeline tasks (fetch, group, merge, upload, embed)
- ├── build/              # Makefile components
- ├── sql/                # Raw SQL scripts for postgres
- ├── shell.nix           # Nix development shell
- ├── TODO.md             # Roadmap and feature list
- └── README.md           # Project overview and usage
- ```
+## Directory Structure
+```
+.
+├── Makefile            # Pipeline tasks (fetch, group, merge, upload, embed)
+├── build/              # Makefile components
+├── frontend/           # PureScript + Halogen UI for browsing verses via PostgREST
+├── sql/                # Raw SQL scripts for postgres
+├── shell.nix           # Nix development shell
+├── TODO.md             # Roadmap and feature list
+└── README.md           # Project overview and usage
+```
+
+## Frontend previewer
+
+A lightweight PureScript/Halogen interface lives in [`frontend/`](frontend/). It connects to the PostgREST schema defined in
+[`sql/postgrest.sql`](sql/postgrest.sql) and lets you:
+
+- Paste multiple Bible addresses separated by semicolons.
+- Choose and freely reorder translations (sources) exposed in the `_all_sources` view.
+- Display the resulting verses grouped by address, with verse references tucked to the margin so the text stays in focus.
+
+See [`frontend/README.md`](frontend/README.md) for build and usage instructions.
 
  ## Contributing
  Contributions are welcome! Please open issues or pull requests.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,32 @@
+# DeepBible PureScript frontend
+
+This directory contains a minimal PureScript/Halogen single page component that talks to the PostgREST API exposed by the DeepBible database helpers.
+
+## Prerequisites
+
+* [Spago](https://github.com/purescript/spago)
+* Node.js runtime (for running the generated JavaScript bundle)
+
+## Install dependencies and build
+
+```bash
+cd frontend
+spago install
+spago bundle-app --main Main --to app.js
+```
+
+The generated bundle will live in `app.js`. You can then serve the contents of the `frontend` directory using any static file server, for example:
+
+```bash
+npx http-server .
+```
+
+## Using the app
+
+1. Start your PostgREST server that exposes the functions defined in `sql/postgrest.sql` (the default URL in the component points at `http://localhost:3000`).
+2. Open `index.html` in your browser (or visit the URL where you serve the `frontend` directory).
+3. Use the address textarea to provide verse addresses, separated by semicolons. Example: `Genesis 1,1-5; John 3,16`.
+4. Choose translations from the available list. They will appear in the order selected; use the arrow buttons to rearrange or remove them.
+5. Click **Fetch verses** to load the passages. Each translation will be displayed in its own column, with verse references in the left margin.
+
+The layout keeps metadata tucked into a narrow margin so that the verse text remains the visual focus.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DeepBible Verse Explorer</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/frontend/packages.dhall
+++ b/frontend/packages.dhall
@@ -1,0 +1,3 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.15-20240203/packages.dhall
+in  upstream

--- a/frontend/spago.dhall
+++ b/frontend/spago.dhall
@@ -1,0 +1,23 @@
+{ name = "deepbible-frontend"
+, dependencies =
+  [ "aff"
+  , "affjax"
+  , "argonaut-core"
+  , "argonaut-codecs"
+  , "arrays"
+  , "console"
+  , "effect"
+  , "either"
+  , "foldable-traversable"
+  , "halogen"
+  , "maybe"
+  , "newtype"
+  , "prelude"
+  , "strings"
+  , "tailrec"
+  ]
+, packages = ./packages.dhall
+, sources =
+  [ "src/**/*.purs"
+  ]
+}

--- a/frontend/src/App/Component.purs
+++ b/frontend/src/App/Component.purs
@@ -1,0 +1,335 @@
+module App.Component where
+
+import Prelude
+
+import App.Util (encodeURIComponent)
+import Affjax as AX
+import Affjax.ResponseFormat as ResponseFormat
+import Data.Argonaut.Decode (class DecodeJson, decodeJson, (.:?))
+import Data.Array (deleteAt, filter, find, findIndex, index, length, snoc)
+import Data.Array as Array
+import Data.Either (Either(..))
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.String as String
+import Data.Traversable (for)
+import Data.Tuple (Tuple(..))
+import Effect.Aff (Aff)
+import Effect.Class (class MonadEffect)
+import Halogen as H
+import Halogen.HTML as HH
+import Halogen.HTML.Events as HE
+import Halogen.HTML.Properties as HP
+
+data Source = Source
+  { id :: String
+  , language :: String
+  , source_number :: Int
+  , name :: String
+  , description_short :: Maybe String
+  }
+
+derive instance eqSource :: Eq Source
+
+instance decodeSource :: DecodeJson Source where
+  decodeJson json = do
+    obj <- decodeJson json
+    id <- obj .:? "id"
+    language <- obj .:? "language"
+    source_number <- obj .:? "source_number"
+    name <- obj .:? "name"
+    description_short <- obj .:? "description_short"
+    pure $ Source { id, language, source_number, name, description_short }
+
+data Verse = Verse
+  { book_number :: Int
+  , chapter :: Int
+  , verse :: Int
+  , verse_id :: String
+  , language :: String
+  , source :: String
+  , address :: String
+  , text :: String
+  }
+
+derive instance eqVerse :: Eq Verse
+
+derive instance ordVerse :: Ord Verse
+
+instance decodeVerse :: DecodeJson Verse where
+  decodeJson json = do
+    obj <- decodeJson json
+    book_number <- obj .:? "book_number"
+    chapter <- obj .:? "chapter"
+    verse <- obj .:? "verse"
+    verse_id <- obj .:? "verse_id"
+    language <- obj .:? "language"
+    source <- obj .:? "source"
+    address <- obj .:? "address"
+    text <- obj .:? "text"
+    pure $ Verse { book_number, chapter, verse, verse_id, language, source, address, text }
+
+
+type AddressResult =
+  { address :: String
+  , verses :: Array TranslationColumn
+  }
+
+type TranslationColumn =
+  { source :: Source
+  , verses :: Array Verse
+  }
+
+type State =
+  { addressesInput :: String
+  , parsedAddresses :: Array String
+  , baseUrl :: String
+  , availableSources :: Array Source
+  , selectedSources :: Array Source
+  , results :: Array AddressResult
+  , loading :: Boolean
+  , error :: Maybe String
+  }
+
+data Action
+  = Initialize
+  | SetBaseUrl String
+  | UpdateAddresses String
+  | AddSource String
+  | RemoveSource String
+  | MoveSourceUp String
+  | MoveSourceDown String
+  | RequestVerses
+  | ReceiveSources (Either String (Array Source))
+  | ReceiveVerses (Either String (Array AddressResult))
+
+component :: forall query input output m. MonadEffect m => H.Component query input output m
+component = H.mkComponent
+  { initialState: const initialState
+  , render
+  , eval: H.mkEval $ H.defaultEval
+      { initialize = Just Initialize
+      , handleAction = handleAction
+      }
+  }
+
+initialState :: State
+initialState =
+  { addressesInput: ""
+  , parsedAddresses: []
+  , baseUrl: "http://localhost:3000"
+  , availableSources: []
+  , selectedSources: []
+  , results: []
+  , loading: false
+  , error: Nothing
+  }
+
+handleAction :: forall output m. MonadEffect m => Action -> H.HalogenM State Action () output m Unit
+handleAction = case _ of
+  Initialize -> do
+    st <- H.get
+    H.modify_ (_ { loading = true, error = Nothing })
+    result <- H.liftAff (fetchSources st.baseUrl)
+    handleAction (ReceiveSources result)
+  SetBaseUrl url ->
+    H.modify_ (_ { baseUrl = url })
+  UpdateAddresses text ->
+    H.modify_ (_ { addressesInput = text })
+  AddSource sourceId -> do
+    st <- H.get
+    case find (matches sourceId) st.availableSources of
+      Nothing -> pure unit
+      Just src -> do
+        let remaining = Array.filter (not <<< matches sourceId) st.availableSources
+            selected = st.selectedSources `snoc` src
+        H.put st { availableSources = remaining, selectedSources = selected }
+  RemoveSource sourceId -> do
+    st <- H.get
+    let selected = Array.filter (not <<< matches sourceId) st.selectedSources
+        removed = Array.filter (matches sourceId) st.selectedSources
+        available = sortSources (st.availableSources <> removed)
+    H.put st { availableSources = available, selectedSources = selected }
+  MoveSourceUp sourceId ->
+    H.modify_ (_ { selectedSources = shift (-1) sourceId })
+  MoveSourceDown sourceId ->
+    H.modify_ (_ { selectedSources = shift 1 sourceId })
+  RequestVerses -> do
+    st <- H.get
+    let addresses = parseAddresses st.addressesInput
+    if Array.null addresses || Array.null st.selectedSources then
+      H.modify_ (_ { error = Just "Type at least one address and choose at least one translation." })
+    else do
+      H.put st { loading = true, parsedAddresses = addresses, error = Nothing }
+      result <- H.liftAff (fetchVerses st.baseUrl addresses st.selectedSources)
+      handleAction (ReceiveVerses result)
+  ReceiveSources (Left err) ->
+    H.modify_ (_ { loading = false, error = Just err })
+  ReceiveSources (Right sources) ->
+    H.modify_ (_ { loading = false, availableSources = sortSources sources })
+  ReceiveVerses (Left err) ->
+    H.modify_ (_ { loading = false, error = Just err })
+  ReceiveVerses (Right results) ->
+    H.modify_ (_ { loading = false, results = results })
+  where
+  matches sourceId (Source s) = s.id == sourceId
+
+  shift delta sourceId sources =
+    case findIndex (matches sourceId) sources of
+      Nothing -> sources
+      Just idx ->
+        let newIndex = clamp 0 (length sources - 1) (idx + delta)
+        in if newIndex == idx then sources else
+          fromMaybe sources do
+            without <- deleteAt idx sources
+            item <- index sources idx
+            Array.insertAt newIndex item without
+
+  clamp lo hi value = max lo (min hi value)
+
+fetchSources :: String -> Aff (Either String (Array Source))
+fetchSources baseUrl = do
+  let request = AX.defaultRequest
+        { url = baseUrl <> "/_all_sources"
+        , responseFormat = ResponseFormat.json
+        }
+  response <- AX.request request
+  pure case response.response of
+    Nothing -> Left "Unable to decode sources response"
+    Just json ->
+      case decodeJson json of
+        Left err -> Left (show err)
+        Right sources -> Right sources
+
+fetchVerses :: String -> Array String -> Array Source -> Aff (Either String (Array AddressResult))
+fetchVerses baseUrl addresses sources = do
+  results <- for addresses \address -> do
+    columns <- for sources \src@(Source s) -> do
+      verses <- requestVerses baseUrl address (Just s.language) (Just s.name)
+      pure { source: src, verses }
+    pure { address, verses: columns }
+  pure (Right results)
+
+requestVerses :: String -> String -> Maybe String -> Maybe String -> Aff (Array Verse)
+requestVerses baseUrl address language source = do
+  let query = baseUrl <> "/rpc/verses_by_address?p_address=" <> encodeURIComponent address
+        <> maybe "" (\lang -> "&p_language=" <> encodeURIComponent lang) language
+        <> maybe "" (\src -> "&p_source=" <> encodeURIComponent src) source
+      request = AX.defaultRequest
+        { url = query
+        , responseFormat = ResponseFormat.json
+        }
+  response <- AX.request request
+  case response.response of
+    Nothing -> pure []
+    Just json ->
+      case decodeJson json of
+        Left _ -> pure []
+        Right verses -> pure verses
+
+parseAddresses :: String -> Array String
+parseAddresses text =
+  Array.filter (not <<< String.null)
+    (Array.map String.trim (String.split (String.Pattern ";") text))
+
+sortSources :: Array Source -> Array Source
+sortSources = Array.sortWith (\(Source s) -> Tuple s.language s.name)
+
+render :: forall m. State -> H.ComponentHTML Action () m
+render state =
+  HH.div [ HP.class_ $ H.ClassName "app" ]
+    [ HH.div [ HP.class_ $ H.ClassName "sidebar" ]
+        [ HH.h1_ [ HH.text "DeepBible verses" ]
+        , HH.div [ HP.class_ $ H.ClassName "control" ]
+            [ HH.label_
+                [ HH.span_ [ HH.text "PostgREST URL" ]
+                , HH.input
+                    [ HP.type_ HP.InputText
+                    , HP.value state.baseUrl
+                    , HE.onValueInput SetBaseUrl
+                    ]
+                ]
+            ]
+        , HH.div [ HP.class_ $ H.ClassName "control" ]
+            [ HH.label_
+                [ HH.span_ [ HH.text "Addresses" ]
+                , HH.textarea
+                    [ HP.rows 4
+                    , HP.value state.addressesInput
+                    , HP.placeholder "Genesis 1,1-5; John 3,16"
+                    , HE.onValueInput UpdateAddresses
+                    ]
+                ]
+            , HH.button
+                [ HP.class_ $ H.ClassName "primary"
+                , HE.onClick (const RequestVerses)
+                ]
+                [ HH.text "Fetch verses" ]
+            ]
+        , HH.div [ HP.class_ $ H.ClassName "control" ]
+            [ HH.h2_ [ HH.text "Translations" ]
+            , HH.p_ [ HH.text "Selected order" ]
+            , HH.ul_ (map renderSelected state.selectedSources)
+            , HH.p_ [ HH.text "Available" ]
+            , HH.ul_ (map renderAvailable state.availableSources)
+            ]
+        , case state.error of
+            Nothing -> HH.text ""
+            Just err -> HH.p [ HP.class_ $ H.ClassName "error" ] [ HH.text err ]
+        ]
+    , HH.div [ HP.class_ $ H.ClassName "content" ]
+        [ if state.loading then HH.p_ [ HH.text "Loading..." ] else HH.text ""
+        , HH.div_ (map renderAddress state.results)
+        ]
+    ]
+  where
+  renderSelected src@(Source s) =
+    HH.li [ HP.class_ $ H.ClassName "selected" ]
+      [ HH.div [ HP.class_ $ H.ClassName "selected-controls" ]
+          [ HH.button [ HE.onClick (const (MoveSourceUp s.id)) ] [ HH.text "↑" ]
+          , HH.button [ HE.onClick (const (MoveSourceDown s.id)) ] [ HH.text "↓" ]
+          , HH.button [ HE.onClick (const (RemoveSource s.id)) ] [ HH.text "✕" ]
+          ]
+      , HH.div [ HP.class_ $ H.ClassName "selected-label" ]
+          [ HH.span [ HP.class_ $ H.ClassName "language" ] [ HH.text s.language ]
+          , HH.span [ HP.class_ $ H.ClassName "name" ] [ HH.text s.name ]
+          ]
+      ]
+
+  renderAvailable src@(Source s) =
+    HH.li [ HP.class_ $ H.ClassName "available" ]
+      [ HH.button
+          [ HP.class_ $ H.ClassName "ghost"
+          , HE.onClick (const (AddSource s.id))
+          ]
+          [ HH.span [ HP.class_ $ H.ClassName "language" ] [ HH.text s.language ]
+          , HH.text " "
+          , HH.text s.name
+          ]
+      , case s.description_short of
+          Nothing -> HH.text ""
+          Just description -> HH.span [ HP.class_ $ H.ClassName "description" ] [ HH.text description ]
+      ]
+
+  renderAddress result =
+    HH.section [ HP.class_ $ H.ClassName "address" ]
+      [ HH.h2_ [ HH.text result.address ]
+      , HH.div [ HP.class_ $ H.ClassName "columns" ] (map renderColumn result.verses)
+      ]
+
+  renderColumn { source: Source s, verses } =
+    HH.article [ HP.class_ $ H.ClassName "column" ]
+      [ HH.header [ HP.class_ $ H.ClassName "column-header" ]
+          [ HH.span [ HP.class_ $ H.ClassName "language" ] [ HH.text s.language ]
+          , HH.span [ HP.class_ $ H.ClassName "name" ] [ HH.text s.name ]
+          ]
+      , HH.div [ HP.class_ $ H.ClassName "verse-group" ] (map renderVerse verses)
+      ]
+
+  renderVerse (Verse v) =
+    HH.div [ HP.class_ $ H.ClassName "verse-line" ]
+      [ HH.div [ HP.class_ $ H.ClassName "meta" ]
+          [ HH.span [ HP.class_ $ H.ClassName "reference" ] [ HH.text (show v.chapter <> ":" <> show v.verse) ]
+          ]
+      , HH.div [ HP.class_ $ H.ClassName "text" ]
+          [ HH.text v.text ]
+      ]

--- a/frontend/src/App/Util.js
+++ b/frontend/src/App/Util.js
@@ -1,0 +1,1 @@
+exports.encodeURIComponent = (value) => window.encodeURIComponent(value);

--- a/frontend/src/App/Util.purs
+++ b/frontend/src/App/Util.purs
@@ -1,0 +1,3 @@
+module App.Util where
+
+foreign import encodeURIComponent :: String -> String

--- a/frontend/src/Main.purs
+++ b/frontend/src/Main.purs
@@ -1,0 +1,13 @@
+module Main where
+
+import Prelude
+
+import Effect (Effect)
+import Halogen.Aff as HA
+import Halogen.VDom.Driver (runUI)
+import App.Component as App
+
+main :: Effect Unit
+main = HA.runHalogenAff do
+  body <- HA.awaitBody
+  runUI App.component unit body

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,219 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Inter", system-ui, sans-serif;
+  background-color: #f5f5f5;
+  color: #1f1f1f;
+}
+
+body {
+  margin: 0;
+  background: var(--background, #f5f5f5);
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 18rem;
+  padding: 1.5rem;
+  background: #fafafa;
+  border-right: 1px solid rgba(0, 0, 0, 0.08);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.sidebar h1 {
+  font-size: 1.2rem;
+  margin: 0 0 1rem 0;
+}
+
+.control {
+  margin-bottom: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.control label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 600;
+}
+
+.control input,
+.control textarea {
+  width: 100%;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 0.4rem;
+  padding: 0.4rem 0.55rem;
+  font-size: 0.9rem;
+  background: white;
+  color: inherit;
+}
+
+.control textarea {
+  resize: vertical;
+  min-height: 4rem;
+}
+
+.primary {
+  align-self: flex-start;
+  border: none;
+  border-radius: 9999px;
+  background: #2c5282;
+  color: #fff;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.control ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.selected,
+.available {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.selected-controls button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0.1rem 0.35rem;
+  border-radius: 0.3rem;
+  font-size: 0.85rem;
+}
+
+.selected-controls button:hover {
+  background: rgba(0, 0, 0, 0.08);
+}
+
+.selected-label {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.selected-label .language {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.available .ghost {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+  font-size: inherit;
+  text-align: left;
+}
+
+.available .description {
+  display: block;
+  font-size: 0.7rem;
+  color: rgba(0, 0, 0, 0.55);
+  margin-left: 0.5rem;
+}
+
+.error {
+  color: #c53030;
+  font-size: 0.85rem;
+}
+
+.content {
+  flex: 1;
+  padding: 1.5rem;
+  overflow-y: auto;
+}
+
+.address {
+  margin-bottom: 1.5rem;
+}
+
+.address h2 {
+  font-size: 1.1rem;
+  margin: 0 0 0.6rem 0;
+}
+
+.columns {
+  display: grid;
+  gap: 1rem;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(14rem, 1fr);
+}
+
+.column {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 0.6rem;
+  padding: 0.75rem;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.column-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  padding-bottom: 0.35rem;
+  margin-bottom: 0.5rem;
+}
+
+.verse-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.verse-line {
+  display: grid;
+  grid-template-columns: 4rem 1fr;
+  gap: 0.5rem;
+  align-items: start;
+}
+
+.verse-line .meta {
+  text-align: right;
+  font-size: 0.75rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.verse-line .text {
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+@media (max-width: 960px) {
+  .app {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .columns {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `frontend/` PureScript + Halogen project for browsing verses via the PostgREST helpers
- implement a minimal UI to paste verse addresses, pick/reorder translations, and render passages with verse metadata on the margin
- document the frontend build/run steps and link the new app from the root README

## Testing
- not run (frontend dependencies require npm/spago tooling)

------
https://chatgpt.com/codex/tasks/task_e_68dfb9a2ba288320a88964f2985062ab